### PR TITLE
Fixed 'RemovedInDjango110Warning: render() must be called with a dict…

### DIFF
--- a/favicon/management/commands/generate_favicon.py
+++ b/favicon/management/commands/generate_favicon.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
         if options['dry_run']:
             self.stdout.write('No operation launched')
         else:
-            generate(source_file, storage, prefix, options['replace'])
+            generate(source_file, storage, prefix, options['replace'], settings.PRECOMPOSED_BGCOLOR)
 
         if options['post_process']:
             self.stdout.write('Launch post process')

--- a/favicon/settings.py
+++ b/favicon/settings.py
@@ -4,3 +4,4 @@ from django.conf import settings
 
 STORAGE = getattr(settings, 'FAVICON_STORAGE', settings.STATICFILES_STORAGE)
 STORAGE_OPTIONS = getattr(settings, 'FAVICON_STORAGE_OPTIONS', {})
+PRECOMPOSED_BGCOLOR = getattr(settings, 'FAVICON_PRECOMPOSED_BG_COLOR', (255, 255, 255))

--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -20,7 +20,7 @@ def alpha_to_color(image, color=(255, 255, 255)):
     bg.paste(image, image)
     return color and bg or image
 
-def generate(source_file, storage, prefix=None, replace=False):
+def generate(source_file, storage, prefix=None, replace=False, fill=None):
     """
     Creates favicons from a source file and upload into storage.
     This also create the ieconfig.xml file.
@@ -64,6 +64,9 @@ def generate(source_file, storage, prefix=None, replace=False):
     for size, output_name in WINDOWS_PNG_SIZES:
         img = Image.open(source_file)
         save_PNG(img, output_name, size)
+    for size in FILLED_SIZES:
+        img = alpha_to_color(Image.open(source_file), fill)
+        save_PNG(img, 'favicon-precomposed-%s.png' % size, (size, size))
     # Create ieconfig.xml
     output_name = 'ieconfig.xml'
     output_file = StringIO()

--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -33,6 +33,8 @@ def generate(source_file, storage, prefix=None, replace=False, fill=None):
     :type prefix: str
     :param replace: Delete file is already existing.
     :type replace: bool
+    :param fill: Background color for generated 'precomposed-' icons
+    :type fill: tuple of length 3, as returned by ImageColor.getrgb(color)
     """
     prefix = prefix or ''
 

--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -45,6 +45,12 @@ def generate(source_file, storage, prefix=None, replace=False):
                 return
         content = File(output_file, name)
         storage._save(name, content)
+
+    def save_PNG(img, output_name, size):
+        img.thumbnail(size=size, resample=Image.ANTIALIAS)
+        output_file = BytesIO()
+        img.save(output_file, format='PNG')
+        write_file(output_file, output_name)
     # Save ICO
     img = Image.open(source_file)
     output_file = BytesIO()

--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -13,6 +13,7 @@ WINDOWS_PNG_SIZES = (
     ((558, 270), 'widetile.png'),
     ((558, 558), 'largetile.png'),
 )
+FILLED_SIZES = (152,)
 
 def alpha_to_color(image, color=(255, 255, 255)):
     bg = Image.new('RGBA', image.size, color)

--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -14,6 +14,10 @@ WINDOWS_PNG_SIZES = (
     ((558, 558), 'largetile.png'),
 )
 
+def alpha_to_color(image, color=(255, 255, 255)):
+    bg = Image.new('RGBA', image.size, color)
+    bg.paste(image, image)
+    return color and bg or image
 
 def generate(source_file, storage, prefix=None, replace=False):
     """

--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -59,17 +59,10 @@ def generate(source_file, storage, prefix=None, replace=False):
     # Save PNG
     for size in PNG_SIZES:
         img = Image.open(source_file)
-        output_file = BytesIO()
-        output_name = 'favicon-%s.png' % size
-        img.thumbnail(size=(size, size), resample=Image.ANTIALIAS)
-        img.save(output_file, format='PNG')
-        write_file(output_file, output_name)
+        save_PNG(img, 'favicon-%s.png' % size, (size, size))
     for size, output_name in WINDOWS_PNG_SIZES:
         img = Image.open(source_file)
-        output_file = BytesIO()
-        img.thumbnail(size=size, resample=Image.ANTIALIAS)
-        img.save(output_file, format='PNG')
-        write_file(output_file, output_name)
+        save_PNG(img, output_name, size)
     # Create ieconfig.xml
     output_name = 'ieconfig.xml'
     output_file = StringIO()

--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -64,7 +64,7 @@ def generate(source_file, storage, prefix=None, replace=False):
     output_name = 'ieconfig.xml'
     output_file = StringIO()
     template = get_template('favicon/ieconfig.xml')
-    output_content = template.render(Context({'tile_color': 'FFFFFF'}))
+    output_content = template.render({'tile_color': 'FFFFFF'})
     output_file.write(output_content)
     write_file(output_file, 'ieconfig.xml')
 


### PR DESCRIPTION
Django==1.9.6, 1.9.7 complains about calling django.template.loader.get_template with a Context object, rather than a dict:

```
$ ./manage.py generate_favicon logo.png
Are you sure you want to continue? [Y/n]
Launch favicon generation and uploading
/home/foo/favicon/utils.py:67: RemovedInDjango110Warning: render() must be called with a dict, 
not a Context.
  output_content = template.render(Context({'tile_color': 'FFFFFF'}))
```

 I simply updated the offending line in utils.py. It seems to work fine now with 1.9.6, 1.9.7, and runtests.py still succeeds:

```
$ ./manage.py generate_favicon logo.png
Are you sure you want to continue? [Y/n] 
Launch favicon generation and uploading
```
