### PR TITLE
Fixed 'RemovedInDjango110Warning'

### DIFF
--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -1,6 +1,5 @@
 """Utilities for :mod:`favicon`."""
 from django.utils.six import BytesIO, StringIO
-from django.template import Context
 from django.template.loader import get_template
 from django.core.files import File
 from PIL import Image
@@ -64,7 +63,7 @@ def generate(source_file, storage, prefix=None, replace=False):
     output_name = 'ieconfig.xml'
     output_file = StringIO()
     template = get_template('favicon/ieconfig.xml')
-    output_content = template.render(Context({'tile_color': 'FFFFFF'}))
+    output_content = template.render({'tile_color': 'FFFFFF'})
     output_file.write(output_content)
     write_file(output_file, 'ieconfig.xml')
 


### PR DESCRIPTION
Django==1.9.6, 1.9.7 complains about calling django.template.loader.get_template with a Context object, rather than a dict:

```
$ ./manage.py generate_favicon logo.png
Are you sure you want to continue? [Y/n]
Launch favicon generation and uploading
/home/foo/favicon/utils.py:67: RemovedInDjango110Warning: render() must be called with a dict, 
not a Context.
  output_content = template.render(Context({'tile_color': 'FFFFFF'}))
```

 I simply updated the offending line in utils.py. It seems to work fine now with 1.9.6, 1.9.7, and runtests.py still succeeds:

```
$ ./manage.py generate_favicon logo.png
Are you sure you want to continue? [Y/n] 
Launch favicon generation and uploading
```
