### PR TITLE
New feature: Add color to transparent image backgrounds

### DIFF
--- a/favicon/management/commands/generate_favicon.py
+++ b/favicon/management/commands/generate_favicon.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
         if options['dry_run']:
             self.stdout.write('No operation launched')
         else:
-            generate(source_file, storage, prefix, options['replace'])
+            generate(source_file, storage, prefix, options['replace'], settings.PRECOMPOSED_BGCOLOR)
 
         if options['post_process']:
             self.stdout.write('Launch post process')

--- a/favicon/settings.py
+++ b/favicon/settings.py
@@ -4,3 +4,4 @@ from django.conf import settings
 
 STORAGE = getattr(settings, 'FAVICON_STORAGE', settings.STATICFILES_STORAGE)
 STORAGE_OPTIONS = getattr(settings, 'FAVICON_STORAGE_OPTIONS', {})
+PRECOMPOSED_BGCOLOR = getattr(settings, 'FAVICON_PRECOMPOSED_BG_COLOR', (255, 255, 255))

--- a/favicon/tests/utils.py
+++ b/favicon/tests/utils.py
@@ -12,6 +12,7 @@ EXPECTED_FILES = (
     'favicon-32.png', 'favicon-57.png', 'favicon-76.png', 'favicon-96.png',
     'favicon-120.png', 'favicon-128.png', 'favicon-144.png', 'favicon-152.png',
     'favicon-180.png', 'favicon-195.png', 'favicon-196.png', 'favicon-228.png',
+    'favicon-precomposed-152.png',
 )
 
 

--- a/favicon/utils.py
+++ b/favicon/utils.py
@@ -12,9 +12,18 @@ WINDOWS_PNG_SIZES = (
     ((558, 270), 'widetile.png'),
     ((558, 558), 'largetile.png'),
 )
+FILLED_SIZES = (152,)
 
+def alpha_to_color(image, color):
+    color = color or (255, 255, 255)
+    bg = Image.new('RGBA', image.size, color)
+    try:
+        bg.paste(image, image)
+    except ValueError:
+        return image
+    return color and bg or image
 
-def generate(source_file, storage, prefix=None, replace=False):
+def generate(source_file, storage, prefix=None, replace=False, fill=None):
     """
     Creates favicons from a source file and upload into storage.
     This also create the ieconfig.xml file.
@@ -27,6 +36,8 @@ def generate(source_file, storage, prefix=None, replace=False):
     :type prefix: str
     :param replace: Delete file is already existing.
     :type replace: bool
+    :param fill: Background color for generated precomposed-* icons
+    :type fill: tuple of length 3, as returned by PIL.ImageColor.getrgb(color)
     """
     prefix = prefix or ''
 
@@ -40,6 +51,12 @@ def generate(source_file, storage, prefix=None, replace=False):
                 return
         content = File(output_file, name)
         storage._save(name, content)
+
+    def save_png(img, output_name, size):
+        img.thumbnail(size=size, resample=Image.ANTIALIAS)
+        output_file = BytesIO()
+        img.save(output_file, format='PNG')
+        write_file(output_file, output_name)
     # Save ICO
     img = Image.open(source_file)
     output_file = BytesIO()
@@ -48,17 +65,13 @@ def generate(source_file, storage, prefix=None, replace=False):
     # Save PNG
     for size in PNG_SIZES:
         img = Image.open(source_file)
-        output_file = BytesIO()
-        output_name = 'favicon-%s.png' % size
-        img.thumbnail(size=(size, size), resample=Image.ANTIALIAS)
-        img.save(output_file, format='PNG')
-        write_file(output_file, output_name)
+        save_png(img, 'favicon-%s.png' % size, (size, size))
     for size, output_name in WINDOWS_PNG_SIZES:
         img = Image.open(source_file)
-        output_file = BytesIO()
-        img.thumbnail(size=size, resample=Image.ANTIALIAS)
-        img.save(output_file, format='PNG')
-        write_file(output_file, output_name)
+        save_png(img, output_name, size)
+    for size in FILLED_SIZES:
+        img = alpha_to_color(Image.open(source_file), fill)
+        save_png(img, 'favicon-precomposed-%s.png' % size, (size, size))
     # Create ieconfig.xml
     output_name = 'ieconfig.xml'
     output_file = StringIO()
@@ -88,5 +101,8 @@ def delete(storage, prefix=None):
         name = 'favicon-%s.png' % size
         delete_file(name)
     for _, name in WINDOWS_PNG_SIZES:
+        delete_file(name)
+    for size in FILLED_SIZES:
+        name = 'favicon-precomposed-%s.png' % size
         delete_file(name)
     delete_file('ieconfig.xml')


### PR DESCRIPTION
Here are those other contributions that I pushed on accident yesterday (slightly modified). runtests.py, management commands, as well as direct calls to utils.generate and utils.delete work fine with Django==1.9.6.
### Reason:
- Many images with transparent backgrounds look ugly when pinned to the iOS home screen.
### Goal:
- Add the ability to generate additional icons with a colored background.
### To Do:
- Add an image with a transparent background to favicon/tests and use it in tests.
- Modify favicon/favicon.html to use the new images
- Update README
